### PR TITLE
Fix image stretching issue for wide and short images

### DIFF
--- a/src/App.module.css
+++ b/src/App.module.css
@@ -10,8 +10,9 @@
   text-align: center;
   inset: 0;
   margin: auto;
-  height: 90%;
+  max-height: 90%;
   max-width: 90%;
+  object-fit: contain;
 }
 
 .postHeader {


### PR DESCRIPTION
Fixes #3

Changes:
- Changed height to max-height to allow flexible sizing
- Added object-fit: contain to preserve aspect ratio

This prevents wide and short images from being stretched vertically when the window is resized.